### PR TITLE
[1/3] base: battery styles

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -2941,6 +2941,20 @@ public final class Settings {
         public static final String VOLUME_PANEL_EXPANDED = "volume_link_expanded";
 
         /**
+         * Int value of the battery style 0 is default
+         *
+         * @hide
+         */
+        public static final String STATUSBAR_BATTERY_STYLE = "statusbar_battery_style";
+
+        /**
+         * int value if the battery percent should be shown never/always/expanded
+         *
+         * @hide
+         */
+        public static final String STATUSBAR_BATTERY_PERCENT = "statusbar_battery_percent";
+
+        /**
          * Custom button brightness value for manual mode
          *
          * @hide

--- a/core/res/res/values/custom_arrays.xml
+++ b/core/res/res/values/custom_arrays.xml
@@ -83,4 +83,20 @@
         <item>@string/app_ops_read_other_accounts</item>
         <item>@string/app_ops_read_phone_info</item>
     </string-array>
+
+    <string-array name="entries_battery_styles" translatable="false">
+        <item>@string/battery_style_none</item>
+        <item>@string/battery_style_default</item>
+        <item>@string/battery_style_bar</item>
+        <item>@string/battery_style_meter_horizontal</item>
+        <item>@string/battery_style_circle</item>
+    </string-array>
+
+    <string-array name="values_battery_styles" translatable="false">
+        <item>-1</item>
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+    </string-array>
 </resources>

--- a/core/res/res/values/custom_strings.xml
+++ b/core/res/res/values/custom_strings.xml
@@ -101,5 +101,11 @@
     <string name="app_ops_use_vibrate">use haptic feedback</string>
     <string name="app_ops_use_voice_volume">use voice volume</string>
     <string name="app_ops_write_mms_storage">write MMS storage</string>
-    
+
+    <string name="battery_style_none">None</string>
+    <string name="battery_style_default">Default</string>
+    <string name="battery_style_bar">Vertical bar</string>
+    <string name="battery_style_meter_horizontal">Horizontal bar</string>
+    <string name="battery_style_circle">Circle</string>
+
 </resources>

--- a/core/res/res/values/custom_symbols.xml
+++ b/core/res/res/values/custom_symbols.xml
@@ -65,6 +65,9 @@
 
   <java-symbol type="drawable" name="expander_open_mtrl_alpha" />
 
+  <java-symbol type="array" name="entries_battery_styles" />
+  <java-symbol type="array" name="values_battery_styles" />
+
   <java-symbol type="bool" name="config_button_brightness_support" />
   <java-symbol type="integer" name="config_button_brightness_default" />
 

--- a/packages/SystemUI/res/layout/battery_circle_percent_view.xml
+++ b/packages/SystemUI/res/layout/battery_circle_percent_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2014 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<com.android.systemui.BatteryCirclePercentView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/battery"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content" />
+

--- a/packages/SystemUI/res/layout/battery_meter_horizontal_view.xml
+++ b/packages/SystemUI/res/layout/battery_meter_horizontal_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2014 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<com.android.systemui.BatteryMeterHorizontalView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/battery"
+    android:layout_height="14.5dp"
+    android:layout_width="wrap_content" />
+

--- a/packages/SystemUI/res/layout/battery_meter_percent_view.xml
+++ b/packages/SystemUI/res/layout/battery_meter_percent_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2014 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<com.android.systemui.BatteryMeterPercentView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/battery"
+    android:layout_height="14.5dp"
+    android:layout_width="wrap_content"
+    android:layout_marginBottom="@dimen/battery_margin_bottom"/>
+

--- a/packages/SystemUI/res/layout/battery_meter_view.xml
+++ b/packages/SystemUI/res/layout/battery_meter_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2014 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License
+  -->
+<com.android.systemui.BatteryMeterView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/battery"
+    android:layout_height="14.5dp"
+    android:layout_width="9.5dp"
+    android:layout_marginBottom="@dimen/battery_margin_bottom"/>
+

--- a/packages/SystemUI/res/layout/keyguard_status_bar.xml
+++ b/packages/SystemUI/res/layout/keyguard_status_bar.xml
@@ -52,16 +52,6 @@
             >
             <include layout="@layout/system_icons" />
         </FrameLayout>
-        <TextView android:id="@+id/battery_level"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="@dimen/header_battery_margin_keyguard"
-            android:paddingEnd="@dimen/battery_level_padding_end"
-            android:textColor="#ffffff"
-            android:visibility="gone"
-            android:textSize="@dimen/battery_level_text_size"
-            android:importantForAccessibility="noHideDescendants"/>
     </LinearLayout>
 
     <com.android.keyguard.CarrierText

--- a/packages/SystemUI/res/layout/status_bar_expanded_header.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded_header.xml
@@ -68,15 +68,6 @@
             >
             <include layout="@layout/system_icons" />
         </FrameLayout>
-        <TextView android:id="@+id/battery_level"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="@dimen/header_battery_margin_expanded"
-            android:paddingEnd="@dimen/battery_level_padding_end"
-            android:textColor="#ffffff"
-            android:textSize="@dimen/battery_level_text_size"
-            android:importantForAccessibility="noHideDescendants"/>
     </LinearLayout>
 
     <TextView

--- a/packages/SystemUI/res/layout/system_icons.xml
+++ b/packages/SystemUI/res/layout/system_icons.xml
@@ -32,9 +32,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="2.5dp"/>
 
-    <!-- battery must be padded below to match assets -->
-    <com.android.systemui.BatteryMeterView android:id="@+id/battery"
-        android:layout_height="14.5dp"
-        android:layout_width="9.5dp"
-        android:layout_marginBottom="@dimen/battery_margin_bottom"/>
+    <LinearLayout
+        android:id="@+id/battery_container"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="center_vertical" />
+
 </LinearLayout>

--- a/packages/SystemUI/src/com/android/systemui/AbstractBatteryView.java
+++ b/packages/SystemUI/src/com/android/systemui/AbstractBatteryView.java
@@ -1,0 +1,209 @@
+/*
+ *  Copyright (C) 2015 The OmniROM Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.os.BatteryManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.android.systemui.statusbar.policy.BatteryController;
+
+public abstract class AbstractBatteryView extends View implements DemoMode,
+        BatteryController.BatteryStateChangeCallback {
+    public static final String TAG = AbstractBatteryView.class.getSimpleName();
+    public static final String ACTION_LEVEL_TEST = "com.android.systemui.BATTERY_LEVEL_TEST";
+
+    protected BatteryController mBatteryController;
+    protected boolean mPowerSaveEnabled;
+    protected boolean mDemoMode;
+    protected BatteryTracker mDemoTracker = new BatteryTracker();
+    protected BatteryTracker mTracker = new BatteryTracker();
+    private boolean mAttached;
+
+    protected class BatteryTracker extends BroadcastReceiver {
+        public static final int UNKNOWN_LEVEL = -1;
+
+        // current battery status
+        int level = UNKNOWN_LEVEL;
+        String percentStr;
+        int plugType;
+        boolean plugged;
+        int health;
+        int status;
+        String technology;
+        int voltage;
+        int temperature;
+        boolean testmode = false;
+
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            final String action = intent.getAction();
+            if (action.equals(Intent.ACTION_BATTERY_CHANGED)) {
+                if (testmode && ! intent.getBooleanExtra("testmode", false)) return;
+
+                level = (int)(100f
+                        * intent.getIntExtra(BatteryManager.EXTRA_LEVEL, 0)
+                        / intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100));
+
+                plugType = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, 0);
+                plugged = plugType != 0;
+                health = intent.getIntExtra(BatteryManager.EXTRA_HEALTH,
+                        BatteryManager.BATTERY_HEALTH_UNKNOWN);
+                status = intent.getIntExtra(BatteryManager.EXTRA_STATUS,
+                        BatteryManager.BATTERY_STATUS_UNKNOWN);
+                technology = intent.getStringExtra(BatteryManager.EXTRA_TECHNOLOGY);
+                voltage = intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0);
+                temperature = intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0);
+
+                setContentDescription(
+                        context.getString(R.string.accessibility_battery_level, level));
+                postInvalidate();
+            } else if (action.equals(ACTION_LEVEL_TEST)) {
+                testmode = true;
+                post(new Runnable() {
+                    int curLevel = 0;
+                    int incr = 1;
+                    int saveLevel = level;
+                    int savePlugged = plugType;
+                    Intent dummy = new Intent(Intent.ACTION_BATTERY_CHANGED);
+                    @Override
+                    public void run() {
+                        if (curLevel < 0) {
+                            testmode = false;
+                            dummy.putExtra("level", saveLevel);
+                            dummy.putExtra("plugged", savePlugged);
+                            dummy.putExtra("testmode", false);
+                        } else {
+                            dummy.putExtra("level", curLevel);
+                            dummy.putExtra("plugged", incr > 0 ? BatteryManager.BATTERY_PLUGGED_AC : 0);
+                            dummy.putExtra("testmode", true);
+                        }
+                        getContext().sendBroadcast(dummy);
+
+                        if (!testmode) return;
+
+                        curLevel += incr;
+                        if (curLevel == 100) {
+                            incr *= -1;
+                        }
+                        postDelayed(this, 200);
+                    }
+                });
+            }
+        }
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(Intent.ACTION_BATTERY_CHANGED);
+        filter.addAction(ACTION_LEVEL_TEST);
+        final Intent sticky = getContext().registerReceiver(mTracker, filter);
+        if (sticky != null) {
+            // preload the battery level
+            mTracker.onReceive(getContext(), sticky);
+        }
+        if (mBatteryController != null && !mAttached) {
+            mBatteryController.addStateChangedCallback(this);
+            mAttached = true;
+        }
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+
+        getContext().unregisterReceiver(mTracker);
+        if (mAttached) {
+            mBatteryController.removeStateChangedCallback(this);
+            mAttached = false;
+        }
+    }
+
+    public AbstractBatteryView(Context context) {
+        this(context, null, 0);
+    }
+
+    public AbstractBatteryView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public AbstractBatteryView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public void setBatteryController(BatteryController batteryController) {
+        mBatteryController = batteryController;
+        mPowerSaveEnabled = mBatteryController.isPowerSave();
+        if (!mAttached) {
+            mBatteryController.addStateChangedCallback(this);
+            mAttached = true;
+        }
+    }
+
+    @Override
+    public void onBatteryLevelChanged(int level, boolean pluggedIn, boolean charging) {
+        // TODO: Use this callback instead of own broadcast receiver.
+    }
+
+    @Override
+    public void onPowerSaveChanged() {
+        mPowerSaveEnabled = mBatteryController.isPowerSave();
+        invalidate();
+    }
+
+    @Override
+    public void dispatchDemoCommand(String command, Bundle args) {
+        if (!mDemoMode && command.equals(COMMAND_ENTER)) {
+            mDemoMode = true;
+            mDemoTracker.level = mTracker.level;
+            mDemoTracker.plugged = mTracker.plugged;
+        } else if (mDemoMode && command.equals(COMMAND_EXIT)) {
+            mDemoMode = false;
+            postInvalidate();
+        } else if (mDemoMode && command.equals(COMMAND_BATTERY)) {
+           String level = args.getString("level");
+           String plugged = args.getString("plugged");
+           if (level != null) {
+               mDemoTracker.level = Math.min(Math.max(Integer.parseInt(level), 0), 100);
+           }
+           if (plugged != null) {
+               mDemoTracker.plugged = Boolean.parseBoolean(plugged);
+           }
+           postInvalidate();
+        }
+    }
+
+    public boolean isHidingPercentViews() {
+        return false;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/BatteryCirclePercentView.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryCirclePercentView.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.os.BatteryManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.view.View;
+import android.util.Log;
+import android.util.DisplayMetrics;
+
+import java.text.NumberFormat;
+
+public class BatteryCirclePercentView extends AbstractBatteryView {
+    public static final String TAG = BatteryCirclePercentView.class.getSimpleName();
+
+    private static final float BOLT_LEVEL_THRESHOLD = 0.3f;  // opaque bolt below this fraction
+    private static final int FULL = 96;
+
+    private final int[] mColors;
+
+    private final Paint mFramePaint, mBatteryPaint, mTextPaint, mBoltPaint;
+    private float mTextHeight;
+    private int mTextSize;
+    private int mTextWidth;
+    private int mCircleWidth;
+    private int mHeight;
+    private int mWidth;
+    private int mStrokeWidth;
+    private int mPercentOffsetY;
+
+    private final int mCriticalLevel;
+    private final int mChargeColor;
+    private final float[] mBoltPoints;
+    private final Path mBoltPath = new Path();
+
+    private final RectF mFrame = new RectF();
+    private final RectF mButtonFrame = new RectF();
+    private final RectF mBoltFrame = new RectF();
+
+    private final Path mShapePath = new Path();
+    private final Path mClipPath = new Path();
+    private final Path mTextPath = new Path();
+
+    private boolean mShowPercent;
+
+    public BatteryCirclePercentView(Context context) {
+        this(context, null, 0);
+    }
+
+    public BatteryCirclePercentView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public BatteryCirclePercentView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+
+        final Resources res = context.getResources();
+        TypedArray atts = context.obtainStyledAttributes(attrs, R.styleable.BatteryMeterView,
+                defStyle, 0);
+        final int frameColor = atts.getColor(R.styleable.BatteryMeterView_frameColor,
+                res.getColor(R.color.batterymeter_frame_color));
+        TypedArray levels = res.obtainTypedArray(R.array.batterymeter_color_levels);
+        TypedArray colors = res.obtainTypedArray(R.array.batterymeter_color_values);
+
+        final int N = levels.length();
+        mColors = new int[2*N];
+        for (int i=0; i<N; i++) {
+            mColors[2*i] = levels.getInt(i, 0);
+            mColors[2*i+1] = colors.getColor(i, 0);
+        }
+        levels.recycle();
+        colors.recycle();
+        atts.recycle();
+
+        mCriticalLevel = mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_criticalBatteryWarningLevel);
+
+        mFramePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mFramePaint.setColor(frameColor);
+        mFramePaint.setDither(true);
+        mFramePaint.setAntiAlias(true);
+        mFramePaint.setStyle(Paint.Style.STROKE);
+        mFramePaint.setStrokeWidth(2);
+        mFramePaint.setPathEffect(null);
+
+        mBatteryPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mBatteryPaint.setDither(true);
+        mBatteryPaint.setAntiAlias(true);
+        mBatteryPaint.setStyle(Paint.Style.STROKE);
+        mBatteryPaint.setPathEffect(null);
+
+        mTextPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        Typeface font = Typeface.create("sans-serif", Typeface.NORMAL);
+        mTextPaint.setTypeface(font);
+        mTextPaint.setTextAlign(Paint.Align.CENTER);
+        mTextSize = getResources().getDimensionPixelSize(R.dimen.battery_level_text_size);
+        mTextPaint.setTextSize(mTextSize);
+
+        mChargeColor = getResources().getColor(R.color.batterymeter_charge_color);
+
+        mBoltPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mBoltPaint.setColor(res.getColor(R.color.batterymeter_bolt_color));
+        mBoltPoints = loadBoltPoints(res);
+
+        Rect bounds = new Rect();
+        final String text = "100%";
+        mTextPaint.getTextBounds(text, 0, text.length(), bounds);
+        mTextWidth = bounds.width();
+
+        // bar width is hardcoded  android:layout_width="9.5dp"
+        DisplayMetrics metrics = res.getDisplayMetrics();
+        mCircleWidth = (int) (14.5 * metrics.density + 0.5f);
+
+        mStrokeWidth = (int) (mCircleWidth / 6f);
+        mBatteryPaint.setStrokeWidth(mStrokeWidth);
+
+        mPercentOffsetY = (int) (1 * metrics.density + 0.5f);
+    }
+
+    public void setShowPercent(boolean showPercent) {
+        mShowPercent = showPercent;
+    }
+
+    private static float[] loadBoltPoints(Resources res) {
+        final int[] pts = res.getIntArray(R.array.batterymeter_bolt_points);
+        int maxX = 0, maxY = 0;
+        for (int i = 0; i < pts.length; i += 2) {
+            maxX = Math.max(maxX, pts[i]);
+            maxY = Math.max(maxY, pts[i + 1]);
+        }
+        final float[] ptsF = new float[pts.length];
+        for (int i = 0; i < pts.length; i += 2) {
+            ptsF[i] = (float)pts[i] / maxX;
+            ptsF[i + 1] = (float)pts[i + 1] / maxY;
+        }
+        return ptsF;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        mWidth = (mShowPercent ? (mTextWidth + mStrokeWidth) : 0) + mCircleWidth + 2 * mStrokeWidth;
+        mHeight = mCircleWidth + 2 * mStrokeWidth;
+        setMeasuredDimension(mWidth, mHeight);
+    }
+
+    private int getColorForLevel(int percent) {
+
+        // If we are in power save mode, always use the normal color.
+        if (mPowerSaveEnabled) {
+            return mColors[mColors.length-1];
+        }
+        int thresh, color = 0;
+        for (int i=0; i<mColors.length; i+=2) {
+            thresh = mColors[i];
+            color = mColors[i+1];
+            if (percent <= thresh) return color;
+        }
+        return color;
+    }
+
+    @Override
+    public void draw(Canvas c) {
+        BatteryTracker tracker = mDemoMode ? mDemoTracker : mTracker;
+        final int level = tracker.level;
+
+        if (level == BatteryTracker.UNKNOWN_LEVEL) return;
+
+        mFrame.set(mStrokeWidth, mStrokeWidth, mHeight - mStrokeWidth, mHeight - mStrokeWidth);
+
+        mBatteryPaint.setColor(tracker.plugged ? mChargeColor : getColorForLevel(level));
+        //mFramePaint.setColor(tracker.plugged ? mChargeColor : getColorForLevel(level));
+
+        // pad circle percentage to 100% once it reaches 97%
+        // for one, the circle looks odd with a too small gap,
+        // for another, some phones never reach 100% due to hardware design
+        int padLevel = level;
+        if (padLevel >= 97) {
+            padLevel = 100;
+        } else if (padLevel <= 3) {
+            // pad nearly invisible below 3% - looks odd
+            padLevel = 3;
+        }
+
+        // draw thin gray ring first
+        c.drawArc(mFrame, 270, 360, false, mFramePaint);
+        // draw colored arc representing charge level
+        c.drawArc(mFrame, 270, 3.6f * padLevel, false, mBatteryPaint);
+
+        if (tracker.plugged) {
+            // define the bolt shape
+            final float bl = mFrame.left + mFrame.width() / 3f;
+            final float bt = mFrame.top + mFrame.height() / 4f;
+            final float br = mFrame.right - mFrame.width() / 4f;
+            final float bb = mFrame.bottom - mFrame.height() / 6f;
+            if (mBoltFrame.left != bl || mBoltFrame.top != bt
+                        || mBoltFrame.right != br || mBoltFrame.bottom != bb) {
+                mBoltFrame.set(bl, bt, br, bb);
+                mBoltPath.reset();
+                mBoltPath.moveTo(
+                        mBoltFrame.left + mBoltPoints[0] * mBoltFrame.width(),
+                        mBoltFrame.top + mBoltPoints[1] * mBoltFrame.height());
+                for (int i = 2; i < mBoltPoints.length; i += 2) {
+                    mBoltPath.lineTo(
+                            mBoltFrame.left + mBoltPoints[i] * mBoltFrame.width(),
+                            mBoltFrame.top + mBoltPoints[i + 1] * mBoltFrame.height());
+                }
+                mBoltPath.lineTo(
+                        mBoltFrame.left + mBoltPoints[0] * mBoltFrame.width(),
+                        mBoltFrame.top + mBoltPoints[1] * mBoltFrame.height());
+            }
+            c.drawPath(mBoltPath, mBoltPaint);
+        }
+
+        if (mShowPercent) {
+            String percentage = NumberFormat.getPercentInstance().format((double) level / 100.0);
+            if (level > mCriticalLevel) {
+                mTextPaint.setColor(getColorForLevel(level));
+            }
+            if (tracker.plugged) {
+                mTextPaint.setColor(mChargeColor);
+            }
+            float textHeight = mTextPaint.descent() - mTextPaint.ascent();
+            float textOffset = (textHeight / 2) - mTextPaint.descent() + mPercentOffsetY;
+            RectF bounds = new RectF(mCircleWidth + 3 * mStrokeWidth, 0, mWidth, mHeight);
+            c.drawText(percentage, bounds.centerX(), bounds.centerY() + textOffset, mTextPaint);
+        }
+    }
+
+    @Override
+    public boolean hasOverlappingRendering() {
+        return false;
+    }
+
+    @Override
+    public boolean isHidingPercentViews() {
+        return true;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/BatteryMeterPercentView.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryMeterPercentView.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.content.res.Resources;
+import android.content.res.TypedArray;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.graphics.Typeface;
+import android.os.BatteryManager;
+import android.os.Bundle;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.view.View;
+import android.util.Log;
+import android.util.DisplayMetrics;
+
+import java.text.NumberFormat;
+
+public class BatteryMeterPercentView extends AbstractBatteryView {
+    public static final String TAG = BatteryMeterPercentView.class.getSimpleName();
+
+    private static final float BOLT_LEVEL_THRESHOLD = 0.2f;  // opaque bolt below this fraction
+    private static final int FULL = 96;
+
+    private final int[] mColors;
+
+    private float mButtonHeightFraction;
+    private float mSubpixelSmoothingLeft;
+    private float mSubpixelSmoothingRight;
+    private final Paint mFramePaint, mBatteryPaint, mTextPaint, mBoltPaint;
+    private float mTextHeight;
+    private int mTextSize;
+    private int mTextWidth;
+    private int mBarWidth;
+    private int mBarSpaceWidth;
+    private int mPercentOffsetY;
+
+    private int mHeight;
+    private int mWidth;
+
+    private final int mCriticalLevel;
+    private final int mChargeColor;
+    private final float[] mBoltPoints;
+    private final Path mBoltPath = new Path();
+
+    private final RectF mFrame = new RectF();
+    private final RectF mButtonFrame = new RectF();
+    private final RectF mBoltFrame = new RectF();
+
+    private final Path mShapePath = new Path();
+    private final Path mClipPath = new Path();
+    private final Path mTextPath = new Path();
+
+    private boolean mShowPercent;
+    private boolean mShowBar;
+    private boolean mFrameMode;
+
+    public BatteryMeterPercentView(Context context) {
+        this(context, null, 0);
+    }
+
+    public BatteryMeterPercentView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public BatteryMeterPercentView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+
+        final Resources res = context.getResources();
+        TypedArray atts = context.obtainStyledAttributes(attrs, R.styleable.BatteryMeterView,
+                defStyle, 0);
+        final int frameColor = atts.getColor(R.styleable.BatteryMeterView_frameColor,
+                res.getColor(R.color.batterymeter_frame_color));
+        TypedArray levels = res.obtainTypedArray(R.array.batterymeter_color_levels);
+        TypedArray colors = res.obtainTypedArray(R.array.batterymeter_color_values);
+
+        final int N = levels.length();
+        mColors = new int[2*N];
+        for (int i=0; i<N; i++) {
+            mColors[2*i] = levels.getInt(i, 0);
+            mColors[2*i+1] = colors.getColor(i, 0);
+        }
+        levels.recycle();
+        colors.recycle();
+        atts.recycle();
+
+        mCriticalLevel = mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_criticalBatteryWarningLevel);
+        mButtonHeightFraction = context.getResources().getFraction(
+                R.fraction.battery_button_height_fraction, 1, 1);
+        mSubpixelSmoothingLeft = context.getResources().getFraction(
+                R.fraction.battery_subpixel_smoothing_left, 1, 1);
+        mSubpixelSmoothingRight = context.getResources().getFraction(
+                R.fraction.battery_subpixel_smoothing_right, 1, 1);
+
+        mFramePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mFramePaint.setColor(frameColor);
+        mFramePaint.setDither(true);
+        mFramePaint.setStrokeWidth(0);
+        mFramePaint.setStyle(Paint.Style.FILL_AND_STROKE);
+
+        mBatteryPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mBatteryPaint.setDither(true);
+        mBatteryPaint.setStrokeWidth(0);
+        mBatteryPaint.setStyle(Paint.Style.FILL_AND_STROKE);
+
+        mTextPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        Typeface font = Typeface.create("sans-serif", Typeface.NORMAL);
+        mTextPaint.setTypeface(font);
+        mTextPaint.setTextAlign(Paint.Align.CENTER);
+        mTextSize = getResources().getDimensionPixelSize(R.dimen.battery_level_text_size);
+        mTextPaint.setTextSize(mTextSize);
+
+        mChargeColor = getResources().getColor(R.color.batterymeter_charge_color);
+
+        mBoltPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mBoltPaint.setColor(res.getColor(R.color.batterymeter_bolt_color));
+        mBoltPoints = loadBoltPoints(res);
+
+        Rect bounds = new Rect();
+        final String text = "100%";
+        mTextPaint.getTextBounds(text, 0, text.length(), bounds);
+        mTextWidth = bounds.width();
+
+        // bar width is hardcoded  android:layout_width="9.5dp"
+        DisplayMetrics metrics = res.getDisplayMetrics();
+        mBarWidth = (int) (9.5 * metrics.density + 0.5f);
+        mBarSpaceWidth = (int) (12 * metrics.density + 0.5f);
+        mPercentOffsetY = (int) (1 * metrics.density + 0.5f);
+    }
+
+    public void setShowPercent(boolean showPercent) {
+        mShowPercent = showPercent;
+    }
+
+    public void setShowBar(boolean showBar) {
+        mShowBar = showBar;
+    }
+
+    public void setFrameMode(boolean frameMode) {
+        mFrameMode = frameMode;
+        if (mFrameMode) {
+            mFramePaint.setStyle(Paint.Style.STROKE);
+            mFramePaint.setStrokeWidth(2);
+        }
+    }
+
+    private static float[] loadBoltPoints(Resources res) {
+        final int[] pts = res.getIntArray(R.array.batterymeter_bolt_points);
+        int maxX = 0, maxY = 0;
+        for (int i = 0; i < pts.length; i += 2) {
+            maxX = Math.max(maxX, pts[i]);
+            maxY = Math.max(maxY, pts[i + 1]);
+        }
+        final float[] ptsF = new float[pts.length];
+        for (int i = 0; i < pts.length; i += 2) {
+            ptsF[i] = (float)pts[i] / maxX;
+            ptsF[i + 1] = (float)pts[i + 1] / maxY;
+        }
+        return ptsF;
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+        mWidth = (mShowPercent ? mTextWidth : 0) + (mShowBar ? mBarSpaceWidth : 0);
+        mHeight = getMeasuredHeight();
+        setMeasuredDimension(mWidth, mHeight);
+    }
+
+    private int getColorForLevel(int percent) {
+
+        // If we are in power save mode, always use the normal color.
+        if (mPowerSaveEnabled) {
+            return mColors[mColors.length-1];
+        }
+        int thresh, color = 0;
+        for (int i=0; i<mColors.length; i+=2) {
+            thresh = mColors[i];
+            color = mColors[i+1];
+            if (percent <= thresh) return color;
+        }
+        return color;
+    }
+
+    @Override
+    public void draw(Canvas c) {
+        BatteryTracker tracker = mDemoMode ? mDemoTracker : mTracker;
+        final int level = tracker.level;
+
+        if (level == BatteryTracker.UNKNOWN_LEVEL) return;
+
+        float drawFrac = (float) level / 100f;
+        final int height = mHeight;
+        final int width = mBarWidth;
+        final int buttonHeight = (int) (height * mButtonHeightFraction);
+
+        if (mShowBar) {
+            mFrame.set(0, 0, width, height);
+
+            // button-frame: area above the battery body
+            mButtonFrame.set(
+                    mFrame.left + Math.round(width * 0.25f),
+                    mFrame.top,
+                    mFrame.right - Math.round(width * 0.25f),
+                    mFrame.top + buttonHeight);
+
+            mButtonFrame.top += mSubpixelSmoothingLeft;
+            mButtonFrame.left += mSubpixelSmoothingLeft;
+            mButtonFrame.right -= mSubpixelSmoothingRight;
+
+            // frame: battery body area
+            mFrame.top += buttonHeight;
+            mFrame.left += mSubpixelSmoothingLeft;
+            mFrame.top += mSubpixelSmoothingLeft;
+            mFrame.right -= mSubpixelSmoothingRight;
+            mFrame.bottom -= mSubpixelSmoothingRight;
+
+            // set the battery charging color
+            mBatteryPaint.setColor(tracker.plugged ? mChargeColor : getColorForLevel(level));
+            if (mFrameMode) {
+                mFramePaint.setColor(tracker.plugged ? mChargeColor : getColorForLevel(level));
+            }
+            if (level >= FULL) {
+                drawFrac = 1f;
+            } else if (level <= mCriticalLevel) {
+                drawFrac = 0f;
+            }
+
+            final float levelTop = drawFrac == 1f ? mButtonFrame.top
+                    : (mFrame.top + (mFrame.height() * (1f - drawFrac)));
+
+            // define the battery shape
+            mShapePath.reset();
+            mShapePath.moveTo(mButtonFrame.left, mButtonFrame.top);
+            mShapePath.lineTo(mButtonFrame.right, mButtonFrame.top);
+            mShapePath.lineTo(mButtonFrame.right, mFrame.top);
+            mShapePath.lineTo(mFrame.right, mFrame.top);
+            mShapePath.lineTo(mFrame.right, mFrame.bottom);
+            mShapePath.lineTo(mFrame.left, mFrame.bottom);
+            mShapePath.lineTo(mFrame.left, mFrame.top);
+            mShapePath.lineTo(mButtonFrame.left, mFrame.top);
+            mShapePath.lineTo(mButtonFrame.left, mButtonFrame.top);
+
+            if (tracker.plugged) {
+                // define the bolt shape
+                final float bl = mFrame.left + mFrame.width() / 4.5f;
+                final float bt = mFrame.top + mFrame.height() / 6f;
+                final float br = mFrame.right - mFrame.width() / 7f;
+                final float bb = mFrame.bottom - mFrame.height() / 10f;
+                if (mBoltFrame.left != bl || mBoltFrame.top != bt
+                        || mBoltFrame.right != br || mBoltFrame.bottom != bb) {
+                    mBoltFrame.set(bl, bt, br, bb);
+                    mBoltPath.reset();
+                    mBoltPath.moveTo(
+                            mBoltFrame.left + mBoltPoints[0] * mBoltFrame.width(),
+                            mBoltFrame.top + mBoltPoints[1] * mBoltFrame.height());
+                    for (int i = 2; i < mBoltPoints.length; i += 2) {
+                        mBoltPath.lineTo(
+                                mBoltFrame.left + mBoltPoints[i] * mBoltFrame.width(),
+                                mBoltFrame.top + mBoltPoints[i + 1] * mBoltFrame.height());
+                    }
+                    mBoltPath.lineTo(
+                            mBoltFrame.left + mBoltPoints[0] * mBoltFrame.width(),
+                            mBoltFrame.top + mBoltPoints[1] * mBoltFrame.height());
+                }
+
+                if (drawFrac <= BOLT_LEVEL_THRESHOLD) {
+                    // draw the bolt if opaque
+                    c.drawPath(mBoltPath, mBoltPaint);
+                } else {
+                    // otherwise cut the bolt out of the overall shape
+                    mShapePath.op(mBoltPath, Path.Op.DIFFERENCE);
+                }
+            }
+
+            // draw the battery shape background
+            c.drawPath(mShapePath, mFramePaint);
+
+            // draw the battery shape, clipped to charging level
+            mFrame.top = levelTop;
+            mClipPath.reset();
+            mClipPath.addRect(mFrame,  Path.Direction.CCW);
+            mShapePath.op(mClipPath, Path.Op.INTERSECT);
+            c.drawPath(mShapePath, mBatteryPaint);
+        }
+        if (mShowPercent) {
+            String percentage = NumberFormat.getPercentInstance().format((double) level / 100.0);
+            if (level > mCriticalLevel) {
+                mTextPaint.setColor(getColorForLevel(level));
+            }
+            if (tracker.plugged) {
+                mTextPaint.setColor(mChargeColor);
+            }
+            float textHeight = mTextPaint.descent() - mTextPaint.ascent();
+            float textOffset = (textHeight / 2) - mTextPaint.descent() + mPercentOffsetY;
+            RectF bounds = new RectF((mShowBar ? mBarSpaceWidth : 0), 0, mWidth, mHeight);
+            c.drawText(percentage, bounds.centerX(), bounds.centerY() + textOffset, mTextPaint);
+        }
+    }
+
+    @Override
+    public boolean hasOverlappingRendering() {
+        return false;
+    }
+
+    @Override
+    public boolean isHidingPercentViews() {
+        if (mFrameMode) {
+            return true;
+        }
+        return mShowPercent;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/BatteryViewManager.java
+++ b/packages/SystemUI/src/com/android/systemui/BatteryViewManager.java
@@ -1,0 +1,216 @@
+/*
+ *  Copyright (C) 2015 The OmniROM Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.systemui;
+
+import android.database.ContentObserver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.os.Handler;
+import android.provider.Settings;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.LinearLayout;
+
+import com.android.systemui.statusbar.policy.BatteryController;
+import com.android.systemui.statusbar.phone.BarTransitions;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class BatteryViewManager {
+    public static final String TAG = BatteryViewManager.class.getSimpleName();
+    private LinearLayout mContainerView;
+    private Context mContext;
+    private Handler mHandler;
+    private int mBatteryStyle;
+    private int mShowPercent;
+    private boolean mExpandedView;
+    private List<AbstractBatteryView> mBatteryStyleList = new ArrayList<AbstractBatteryView>();
+    private AbstractBatteryView mCurrentBatteryView;
+    private BatteryController mBatteryController;
+    private BarTransitions mBarTransitions;
+    private BatteryViewManagerObserver mBatteryStyleObserver;
+
+    public interface BatteryViewManagerObserver {
+        public void batteryStyleChanged(AbstractBatteryView batteryStyle);
+
+        public boolean isExpandedBatteryView();
+    }
+
+    private ContentObserver mSettingsObserver = new ContentObserver(mHandler) {
+        @Override
+        public void onChange(boolean selfChange) {
+            final int style = Settings.System.getInt(mContext.getContentResolver(),
+                    Settings.System.STATUSBAR_BATTERY_STYLE, 0);
+            final int showPercent = Settings.System.getInt(mContext.getContentResolver(),
+                    Settings.System.STATUSBAR_BATTERY_PERCENT, 2);
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    switchBatteryStyle(style, showPercent);
+                }
+            });
+        }
+    };
+
+    public BatteryViewManager(Context context, LinearLayout mContainer, BarTransitions barTransitions,
+        BatteryViewManagerObserver observer) {
+        mContext = context;
+        mContainerView = mContainer;
+        mBarTransitions = barTransitions;
+        mBatteryStyleObserver = observer;
+        mHandler = new Handler();
+
+        BatteryMeterPercentView bmpv = (BatteryMeterPercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_percent_view, mContainerView, false);
+        bmpv.setShowBar(true);
+        bmpv.setShowPercent(false);
+        mBatteryStyleList.add(bmpv);
+
+        BatteryMeterPercentView bmpv1 = (BatteryMeterPercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_percent_view, mContainerView, false);
+        bmpv1.setShowBar(true);
+        bmpv1.setShowPercent(true);
+        mBatteryStyleList.add(bmpv1);
+
+        BatteryMeterPercentView bmpv2 = (BatteryMeterPercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_percent_view, mContainerView, false);
+        bmpv2.setShowBar(true);
+        bmpv2.setShowPercent(false);
+        bmpv2.setFrameMode(true);
+        mBatteryStyleList.add(bmpv2);
+
+        BatteryMeterPercentView bmpv3 = (BatteryMeterPercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_percent_view, mContainerView, false);
+        bmpv3.setShowBar(true);
+        bmpv3.setShowPercent(true);
+        bmpv3.setFrameMode(true);
+        mBatteryStyleList.add(bmpv3);
+
+        BatteryMeterPercentView bmpv4 = (BatteryMeterPercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_percent_view, mContainerView, false);
+        bmpv4.setShowBar(false);
+        bmpv4.setShowPercent(true);
+        bmpv4.setFrameMode(true);
+        mBatteryStyleList.add(bmpv4);
+
+        BatteryMeterHorizontalView bmhv = (BatteryMeterHorizontalView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_horizontal_view, mContainerView, false);
+        bmhv.setShowPercent(false);
+        mBatteryStyleList.add(bmhv);
+
+        BatteryMeterHorizontalView bmhv1 = (BatteryMeterHorizontalView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_meter_horizontal_view, mContainerView, false);
+        bmhv1.setShowPercent(true);
+        mBatteryStyleList.add(bmhv1);
+
+        BatteryCirclePercentView bmcv = (BatteryCirclePercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_circle_percent_view, mContainerView, false);
+        bmcv.setShowPercent(false);
+        mBatteryStyleList.add(bmcv);
+
+        BatteryCirclePercentView bmcv1 = (BatteryCirclePercentView) LayoutInflater.from(mContext).inflate(
+                R.layout.battery_circle_percent_view, mContainerView, false);
+        bmcv1.setShowPercent(true);
+        mBatteryStyleList.add(bmcv1);
+
+        mBatteryStyle = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.STATUSBAR_BATTERY_STYLE, 0);
+        mShowPercent = Settings.System.getInt(mContext.getContentResolver(),
+                Settings.System.STATUSBAR_BATTERY_PERCENT, 2);
+
+        mContext.getContentResolver().registerContentObserver(
+                Settings.System.getUriFor(Settings.System.STATUSBAR_BATTERY_STYLE), false,
+                mSettingsObserver);
+        mContext.getContentResolver().registerContentObserver(
+                Settings.System.getUriFor(Settings.System.STATUSBAR_BATTERY_PERCENT), false,
+                mSettingsObserver);
+
+        mExpandedView = observer != null ? observer.isExpandedBatteryView() : false;
+        int batteryIndex = getStyleFromSettings();
+        if (batteryIndex != -1) {
+            mCurrentBatteryView = mBatteryStyleList.get(batteryIndex);
+        }
+    }
+
+    public void setBatteryController(BatteryController batteryController) {
+        mBatteryController = batteryController;
+
+        if (mCurrentBatteryView != null) {
+            mCurrentBatteryView.setBatteryController(mBatteryController);
+            mContainerView.addView(mCurrentBatteryView);
+            if (mBarTransitions != null) {
+                mBarTransitions.updateBattery(mCurrentBatteryView);
+            }
+        }
+        notifyObserver();
+    }
+
+    private int getStyleFromSettings() {
+        boolean showPercent = mExpandedView ? mShowPercent != 0 : mShowPercent == 1;
+        switch(mBatteryStyle) {
+            case -1:
+                return showPercent ? 4 : -1;
+            case 0:
+                return showPercent ? 1 : 0;
+            case 1:
+                return showPercent ? 3 : 2;
+            case 2:
+                return showPercent ? 6 : 5;
+            case 3:
+                return showPercent ? 8 : 7;
+        }
+        return 0;
+    }
+
+    private void switchBatteryStyle(int style, int showPercent) {
+        if (mBatteryStyle == style && showPercent == mShowPercent) {
+            return;
+        }
+        if (style >= mBatteryStyleList.size()) {
+            return;
+        }
+
+        mBatteryStyle = style;
+        mShowPercent = showPercent;
+        mContainerView.removeView(mCurrentBatteryView);
+        mCurrentBatteryView = null;
+
+        int batteryIndex = getStyleFromSettings();
+        if (batteryIndex != -1) {
+            mCurrentBatteryView = mBatteryStyleList.get(batteryIndex);
+            mCurrentBatteryView.setBatteryController(mBatteryController);
+            mContainerView.addView(mCurrentBatteryView);
+        }
+        if (mBarTransitions != null) {
+            mBarTransitions.updateBattery(mCurrentBatteryView);
+        }
+        notifyObserver();
+    }
+
+    private void notifyObserver() {
+        if (mBatteryStyleObserver != null) {
+            mBatteryStyleObserver.batteryStyleChanged(mCurrentBatteryView);
+        }
+    }
+
+    public AbstractBatteryView getCurrentBatteryView() {
+        return mCurrentBatteryView;
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/BarTransitions.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/BarTransitions.java
@@ -32,6 +32,7 @@ import android.view.View;
 import android.view.animation.LinearInterpolator;
 
 import com.android.systemui.R;
+import com.android.systemui.AbstractBatteryView;
 
 public class BarTransitions {
     private static final boolean DEBUG = false;
@@ -64,6 +65,9 @@ public class BarTransitions {
         if (HIGH_END) {
             mView.setBackground(mBarBackground);
         }
+    }
+
+    public void updateBattery(AbstractBatteryView battery) {
     }
 
     public int getMode() {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -1569,7 +1569,6 @@ public class NotificationPanelView extends PanelView implements
 
     private void setListening(boolean listening) {
         mHeader.setListening(listening);
-        mKeyguardStatusBar.setListening(listening);
         mQsPanel.setListening(listening);
     }
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -123,7 +123,7 @@ import com.android.internal.statusbar.StatusBarIcon;
 import com.android.internal.util.omni.TaskUtils;
 import com.android.keyguard.KeyguardHostView.OnDismissAction;
 import com.android.keyguard.ViewMediatorCallback;
-import com.android.systemui.BatteryMeterView;
+import com.android.systemui.BatteryViewManager;
 import com.android.systemui.DemoMode;
 import com.android.systemui.EventLogConstants;
 import com.android.systemui.EventLogTags;
@@ -275,6 +275,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
 
     StatusBarWindowView mStatusBarWindow;
     PhoneStatusBarView mStatusBarView;
+    BatteryViewManager mBatteryViewManager;
     private int mStatusBarWindowState = WINDOW_STATE_SHOWING;
     private StatusBarWindowManager mStatusBarWindowManager;
     private UnlockMethodCache mUnlockMethodCache;
@@ -917,8 +918,11 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         mUserInfoController.reloadUserInfo();
 
         mHeader.setBatteryController(mBatteryController);
-        ((BatteryMeterView) mStatusBarView.findViewById(R.id.battery)).setBatteryController(
-                mBatteryController);
+
+        LinearLayout batteryContainer = (LinearLayout) mStatusBarView.findViewById(R.id.battery_container);
+        mBatteryViewManager = new BatteryViewManager(mContext, batteryContainer, mStatusBarView.getBarTransitions(), null);
+        mBatteryViewManager.setBatteryController(mBatteryController);
+
         mKeyguardStatusBar.setBatteryController(mBatteryController);
         mHeader.setNextAlarmController(mNextAlarmController);
 
@@ -3578,7 +3582,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             dispatchDemoCommandToView(command, args, R.id.clock);
         }
         if (modeChange || command.equals(COMMAND_BATTERY)) {
-            dispatchDemoCommandToView(command, args, R.id.battery);
+            View battery = mBatteryViewManager.getCurrentBatteryView();
+            if (battery != null) {
+                dispatchDemoCommandToView(command, args, battery);
+            }
         }
         if (modeChange || command.equals(COMMAND_STATUS)) {
             if (mDemoStatusIcons == null) {
@@ -3621,6 +3628,13 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     private void dispatchDemoCommandToView(String command, Bundle args, int id) {
         if (mStatusBarView == null) return;
         View v = mStatusBarView.findViewById(id);
+        if (v instanceof DemoMode) {
+            ((DemoMode)v).dispatchDemoCommand(command, args);
+        }
+    }
+
+    private void dispatchDemoCommandToView(String command, Bundle args, View v) {
+        if (mStatusBarView == null) return;
         if (v instanceof DemoMode) {
             ((DemoMode)v).dispatchDemoCommand(command, args);
         }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarTransitions.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBarTransitions.java
@@ -21,8 +21,10 @@ import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
 import android.content.res.Resources;
 import android.view.View;
+import android.widget.LinearLayout;
 
 import com.android.systemui.R;
+import com.android.systemui.AbstractBatteryView;
 
 public final class PhoneStatusBarTransitions extends BarTransitions {
     private static final float ICON_ALPHA_WHEN_NOT_OPAQUE = 1;
@@ -32,8 +34,9 @@ public final class PhoneStatusBarTransitions extends BarTransitions {
     private final PhoneStatusBarView mView;
     private final float mIconAlphaWhenOpaque;
 
-    private View mLeftSide, mStatusIcons, mSignalCluster, mBattery, mClock;
+    private View mLeftSide, mStatusIcons, mSignalCluster, mClock;
     private Animator mCurrentAnimation;
+    private AbstractBatteryView mBattery;
 
     public PhoneStatusBarTransitions(PhoneStatusBarView view) {
         super(view, R.drawable.status_background);
@@ -46,10 +49,13 @@ public final class PhoneStatusBarTransitions extends BarTransitions {
         mLeftSide = mView.findViewById(R.id.notification_icon_area);
         mStatusIcons = mView.findViewById(R.id.statusIcons);
         mSignalCluster = mView.findViewById(R.id.signal_cluster);
-        mBattery = mView.findViewById(R.id.battery);
         mClock = mView.findViewById(R.id.clock);
         applyModeBackground(-1, getMode(), false /*animate*/);
         applyMode(getMode(), false /*animate*/);
+    }
+
+    public void updateBattery(AbstractBatteryView battery) {
+        mBattery = battery;
     }
 
     public ObjectAnimator animateTransitionTo(View v, float toAlpha) {
@@ -87,13 +93,23 @@ public final class PhoneStatusBarTransitions extends BarTransitions {
         }
         if (animate) {
             AnimatorSet anims = new AnimatorSet();
-            anims.playTogether(
+            if (mBattery != null) {
+                anims.playTogether(
                     animateTransitionTo(mLeftSide, newAlpha),
                     animateTransitionTo(mStatusIcons, newAlpha),
                     animateTransitionTo(mSignalCluster, newAlpha),
                     animateTransitionTo(mBattery, newAlphaBC),
                     animateTransitionTo(mClock, newAlphaBC)
                     );
+
+            } else {
+                anims.playTogether(
+                    animateTransitionTo(mLeftSide, newAlpha),
+                    animateTransitionTo(mStatusIcons, newAlpha),
+                    animateTransitionTo(mSignalCluster, newAlpha),
+                    animateTransitionTo(mClock, newAlphaBC)
+                    );
+            }
             if (isLightsOut(mode)) {
                 anims.setDuration(LIGHTS_OUT_DURATION);
             }
@@ -103,7 +119,9 @@ public final class PhoneStatusBarTransitions extends BarTransitions {
             mLeftSide.setAlpha(newAlpha);
             mStatusIcons.setAlpha(newAlpha);
             mSignalCluster.setAlpha(newAlpha);
-            mBattery.setAlpha(newAlphaBC);
+            if (mBattery != null) {
+                mBattery.setAlpha(newAlphaBC);
+            }
             mClock.setAlpha(newAlphaBC);
         }
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarHeaderView.java
@@ -29,6 +29,8 @@ import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.util.MathUtils;
 import android.util.TypedValue;
+import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
@@ -39,7 +41,8 @@ import android.widget.Switch;
 import android.widget.TextView;
 
 import com.android.keyguard.KeyguardStatusView;
-import com.android.systemui.BatteryMeterView;
+import com.android.systemui.BatteryViewManager;
+import com.android.systemui.AbstractBatteryView;
 import com.android.systemui.FontSizeUtils;
 import com.android.systemui.R;
 import com.android.systemui.qs.QSPanel;
@@ -54,7 +57,8 @@ import java.text.NumberFormat;
  * The view to manage the header area in the expanded status bar.
  */
 public class StatusBarHeaderView extends RelativeLayout implements View.OnClickListener,
-        BatteryController.BatteryStateChangeCallback, NextAlarmController.NextAlarmChangeCallback {
+        NextAlarmController.NextAlarmChangeCallback,
+        BatteryViewManager.BatteryViewManagerObserver {
 
     private boolean mExpanded;
     private boolean mListening;
@@ -77,7 +81,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
     private Switch mQsDetailHeaderSwitch;
     private ImageView mQsDetailHeaderProgress;
     private TextView mEmergencyCallsOnly;
-    private TextView mBatteryLevel;
     private TextView mAlarmStatus;
 
     private boolean mShowEmergencyCallsOnly;
@@ -121,6 +124,7 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
 
     private float mCurrentT;
     private boolean mShowingDetail;
+    private BatteryViewManager mBatteryViewManager;
 
     public StatusBarHeaderView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -148,7 +152,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
         mQsDetailHeaderSwitch = (Switch) mQsDetailHeader.findViewById(android.R.id.toggle);
         mQsDetailHeaderProgress = (ImageView) findViewById(R.id.qs_detail_header_progress);
         mEmergencyCallsOnly = (TextView) findViewById(R.id.header_emergency_calls_only);
-        mBatteryLevel = (TextView) findViewById(R.id.battery_level);
         mAlarmStatus = (TextView) findViewById(R.id.alarm_status);
         mAlarmStatus.setOnClickListener(this);
         mSignalCluster = findViewById(R.id.signal_cluster);
@@ -178,6 +181,8 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
             }
         });
         requestCaptureValues();
+        LinearLayout batteryContainer = (LinearLayout) findViewById(R.id.battery_container);
+        mBatteryViewManager = new BatteryViewManager(mContext, batteryContainer, null, this);
     }
 
     @Override
@@ -198,7 +203,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
     @Override
     protected void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
-        FontSizeUtils.updateFontSize(mBatteryLevel, R.dimen.battery_level_text_size);
         FontSizeUtils.updateFontSize(mEmergencyCallsOnly,
                 R.dimen.qs_emergency_calls_only_text_size);
         FontSizeUtils.updateFontSize(mDateCollapsed, R.dimen.qs_date_collapsed_size);
@@ -265,7 +269,7 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
 
     public void setBatteryController(BatteryController batteryController) {
         mBatteryController = batteryController;
-        ((BatteryMeterView) findViewById(R.id.battery)).setBatteryController(batteryController);
+        mBatteryViewManager.setBatteryController(mBatteryController);
     }
 
     public void setNextAlarmController(NextAlarmController nextAlarmController) {
@@ -327,7 +331,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
             updateSignalClusterDetachment();
         }
         mEmergencyCallsOnly.setVisibility(mExpanded && mShowEmergencyCallsOnly ? VISIBLE : GONE);
-        mBatteryLevel.setVisibility(mExpanded ? View.VISIBLE : View.GONE);
     }
 
     private void updateSignalClusterDetachment() {
@@ -360,10 +363,8 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
 
     private void updateListeners() {
         if (mListening) {
-            mBatteryController.addStateChangedCallback(this);
             mNextAlarmController.addStateChangedCallback(this);
         } else {
-            mBatteryController.removeStateChangedCallback(this);
             mNextAlarmController.removeStateChangedCallback(this);
         }
     }
@@ -390,17 +391,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
     private void updateAmPmTranslation() {
         boolean rtl = getLayoutDirection() == LAYOUT_DIRECTION_RTL;
         mAmPm.setTranslationX((rtl ? 1 : -1) * mTime.getWidth() * (1 - mTime.getScaleX()));
-    }
-
-    @Override
-    public void onBatteryLevelChanged(int level, boolean pluggedIn, boolean charging) {
-        String percentage = NumberFormat.getPercentInstance().format((double) level / 100.0);
-        mBatteryLevel.setText(percentage);
-    }
-
-    @Override
-    public void onPowerSaveChanged() {
-        // could not care less
     }
 
     @Override
@@ -563,7 +553,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
                     + mSystemIconsContainer.getLeft();
         }
         target.batteryY = mSystemIconsSuperContainer.getTop() + mSystemIconsContainer.getTop();
-        target.batteryLevelAlpha = getAlphaForVisibility(mBatteryLevel);
         target.settingsAlpha = getAlphaForVisibility(mSettingsButton);
         target.settingsTranslation = mExpanded
                 ? 0
@@ -629,7 +618,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
         }
         applyAlpha(mDateCollapsed, values.dateCollapsedAlpha);
         applyAlpha(mDateExpanded, values.dateExpandedAlpha);
-        applyAlpha(mBatteryLevel, values.batteryLevelAlpha);
         applyAlpha(mSettingsButton, values.settingsAlpha);
         applyAlpha(mSignalCluster, values.signalClusterAlpha);
         if (!mExpanded) {
@@ -657,7 +645,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
         float avatarY;
         float batteryX;
         float batteryY;
-        float batteryLevelAlpha;
         float settingsAlpha;
         float settingsTranslation;
         float signalClusterAlpha;
@@ -683,7 +670,6 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
             signalClusterAlpha = v1.signalClusterAlpha * (1 - t2) + v2.signalClusterAlpha * t2;
 
             float t3 = Math.max(0, t - 0.7f) / 0.3f;
-            batteryLevelAlpha = v1.batteryLevelAlpha * (1 - t3) + v2.batteryLevelAlpha * t3;
             settingsAlpha = v1.settingsAlpha * (1 - t3) + v2.settingsAlpha * t3;
             dateExpandedAlpha = v1.dateExpandedAlpha * (1 - t3) + v2.dateExpandedAlpha * t3;
             dateCollapsedAlpha = v1.dateCollapsedAlpha * (1 - t3) + v2.dateCollapsedAlpha * t3;
@@ -793,4 +779,13 @@ public class StatusBarHeaderView extends RelativeLayout implements View.OnClickL
                     .start();
         }
     };
+
+    @Override
+    public void batteryStyleChanged(AbstractBatteryView batteryStyle) {
+    }
+
+    @Override
+    public boolean isExpandedBatteryView() {
+        return true;
+    }
 }


### PR DESCRIPTION
BatteryViewManager knows all the different battery styles and
will switch based on settings. No more need to mess with the
global layouts.

All required to add a new style is to add it to BatteryViewManager
and to the resource array of the styles

Start with basic bar and circle styles and optional battery percent support.
More can be added over time

Change-Id: If44dda883a1a53796a0eda54cd208f0b0802df01