### PR TITLE
base: added national roaming for Network Norway

### DIFF
--- a/core/res/res/values-mcc242-mnc05/config.xml
+++ b/core/res/res/values-mcc242-mnc05/config.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2013, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+    <!-- Don't use roaming icon for considered operators -->
+    <string-array translatable="false" name="config_operatorConsideredNonRoaming">
+        <item>24202</item>
+    </string-array>
+</resources>


### PR DESCRIPTION
Users of Network Norway MCC 242 MNC 05 can roam on NetCom GSM MCC 242 MNC 02

Change-Id: Iabc31ee2b5003354946e9d40d504cdf00e5e3b15